### PR TITLE
Changes some docstrings to raw strings

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -147,7 +147,7 @@ summary = "brain-dead simple config-ini parsing"
 
 [[package]]
 name = "ipykernel"
-version = "6.22.0"
+version = "6.23.1"
 requires_python = ">=3.8"
 summary = "IPython Kernel for Jupyter"
 dependencies = [
@@ -706,9 +706,9 @@ content_hash = "sha256:99567f07111a6525a9bfbea546422de6af405cb8b5dd8caa831ae94da
     {url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
     {url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
 ]
-"ipykernel 6.22.0" = [
-    {url = "https://files.pythonhosted.org/packages/48/1b/260b3e4d2f633c1c9019e25a977a9e82341d0713ad8fb60e01b97b7559a4/ipykernel-6.22.0-py3-none-any.whl", hash = "sha256:1ae6047c1277508933078163721bbb479c3e7292778a04b4bacf0874550977d6"},
-    {url = "https://files.pythonhosted.org/packages/bc/18/a773c8f970269988c56678c7b8739b106c5557e419864481c90949db3754/ipykernel-6.22.0.tar.gz", hash = "sha256:302558b81f1bc22dc259fb2a0c5c7cf2f4c0bdb21b50484348f7bafe7fb71421"},
+"ipykernel 6.23.1" = [
+    {url = "https://files.pythonhosted.org/packages/15/43/d2ebd2657b77cb1e2526a4b444a494298dae1c870a27e85805039e1e3e8a/ipykernel-6.23.1.tar.gz", hash = "sha256:1aba0ae8453e15e9bc6b24e497ef6840114afcdb832ae597f32137fa19d42a6f"},
+    {url = "https://files.pythonhosted.org/packages/5d/4b/ffb537e392e730c9a5b02758f9c87077d9087bcb0d957853e13f121e5ea7/ipykernel-6.23.1-py3-none-any.whl", hash = "sha256:77aeffab056c21d16f1edccdc9e5ccbf7d96eb401bd6703610a21be8b068aadc"},
 ]
 "ipython 8.13.2" = [
     {url = "https://files.pythonhosted.org/packages/d5/16/2161195dd2f617933f8ada5bc567eb47ddbb7c99dc16ffa3e729dd25a1a0/ipython-8.13.2-py3-none-any.whl", hash = "sha256:ffca270240fbd21b06b2974e14a86494d6d29290184e788275f55e0b55914926"},

--- a/uegdielectric/dielectric/_Mermin_integrals.py
+++ b/uegdielectric/dielectric/_Mermin_integrals.py
@@ -1,6 +1,4 @@
 """
-Created on Thu Nov 21 14:22:36 2019
-
 @author: tommy
 
 Helper functions to numerically calculates the Mermin dielectric function.
@@ -104,7 +102,7 @@ def realintegrand(p, k, omega, nu, kBT, mu, dosratio=1):
 
 
 def DEtransform(u, k, omega, nu, kBT, mu, plim, dosratio):
-    """
+    r"""
     Transform the real integral using a Double Exponential (DE) change of
     variables.
 

--- a/uegdielectric/dielectric/dielectric_class.py
+++ b/uegdielectric/dielectric/dielectric_class.py
@@ -26,7 +26,8 @@ class Mermin(AbstractDielectric):
     collfreq : float or function, optional
         Electron-ion collision frequency, which depends on the material we
         are modelling as an electron gas. Can be a function of the frequency
-        of the pertubation. If it is a function, it must have only one argument that is of type float and be defined for all nonegative numbers.
+        of the pertubation. If it is a function, it must have only one argument that is
+        of type float and be defined for all nonegative numbers.
     """
 
     def __init__(self, electrongas, collfreq=None):
@@ -119,8 +120,12 @@ class RPA(Mermin):
 
     Notes:
     ______
-     In the collective limit (for example, for small wavenumbers), it can be helpful to damp the RPA response with a small collision frequency to avoid numerical issues. How small is up to you (the larger the value, the less RPA-like the calculation), but a good first attempt is
-     0.03675 ~ 1/27.2114 = 1/Ha, where Ha = Hartree energy = 27.2114 eV. The following example shows how this can be done.
+     In the collective limit (for example, for small wavenumbers), it can be helpful to
+     dampen the RPA response with a small collision frequency to avoid numerical
+     issues. How small is up to you (the larger the value, the less RPA-like the
+     calculation), but a good first attempt is
+     0.03675 ~ 1/27.2114 = 1/Ha, where Ha = Hartree energy = 27.2114 eV. The following
+     example shows how this can be done.
 
      >>> RPA.collfreq(1/27.2114)
     """

--- a/uegdielectric/electrongas/_inv_fermi_integral.py
+++ b/uegdielectric/electrongas/_inv_fermi_integral.py
@@ -4,7 +4,7 @@ import numpy as np
 
 
 def inv_fdint_onehalf(density, temp):
-    """
+    r"""
     Calculates the chemical potential (:math:`\mu`) given the electron density
     and thermal energy by inverting the complete Fermi-Dirac integral of order
     1/2.

--- a/uegdielectric/electrongas/tests/test_inv_fdint_onehalf.py
+++ b/uegdielectric/electrongas/tests/test_inv_fdint_onehalf.py
@@ -8,7 +8,7 @@ from uegdielectric.electrongas._inv_fermi_integral import inv_fdint_onehalf
 class Test_inv_fdint_onehalf:
     @classmethod
     def setup_class(cls):
-        """
+        r"""
         Initialize parameters for tests.
 
         Testing the degenerate (:math:`\eta >> 1`) (where
@@ -30,8 +30,8 @@ class Test_inv_fdint_onehalf:
         cls.den = [0.0267962, 0.00129713, 0.0203079]
 
     def test_known1(self):
-        """
-        Test inv_fdint_onehalf for a known value with :math:`eta >> 1`
+        r"""
+        Test inv_fdint_onehalf for a known value with :math:`\eta >> 1`
         """
         methodval = inv_fdint_onehalf(self.den[0], self.temp[0])
         testTrue = np.isclose(methodval, self.chempot[0], rtol=0.0, atol=1e-4)
@@ -42,8 +42,8 @@ class Test_inv_fdint_onehalf:
         assert testTrue, errStr
 
     def test_known2(self):
-        """
-        Test inv_fdint_onehalf for a known value with :math:`eta \approx 1`
+        r"""
+        Test inv_fdint_onehalf for a known value with :math:`\eta \approx 1`
         """
         methodval = inv_fdint_onehalf(self.den[1], self.temp[1])
         testTrue = np.isclose(methodval, self.chempot[1], rtol=0.0, atol=1e-4)
@@ -54,8 +54,8 @@ class Test_inv_fdint_onehalf:
         assert testTrue, errStr
 
     def test_known3(self):
-        """
-        Test inv_fdint_onehalf for a known value with :math:`eta << 1`
+        r"""
+        Test inv_fdint_onehalf for a known value with :math:`\eta << 1`
         """
         methodval = inv_fdint_onehalf(self.den[2], self.temp[2])
         testTrue = np.isclose(methodval, self.chempot[2], rtol=0.0, atol=1e-4)


### PR DESCRIPTION
Prevents warnings like: DeprecationWarning: invalid escape sequence '\p'